### PR TITLE
fix: sidebar in fullscreen and sidebar extensions

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -18,11 +18,20 @@
 }
 /* The browser-content */
 #tabbrowser-tabbox {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+/* The sidebar when enabled */
+#tabbrowser-tabbox[sidebar-shown] {
   margin-left: var(--left-margin) !important;
   margin-right: var(--right-margin) !important;
 }
-[inFullscreen] #tabbrowser-tabbox {
-  margin-left: var(--left-margin) !important;
+/* Hides the sidebar when in fullscreen */
+[inFullscreen] #tabbrowser-tabbox[sidebar-shown] {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
 }
 /* When not hovering cancel the default crap behavior of the expanded feature */
 #sidebar-main:not(:hover), #sidebar-main:not(:hover) .tabbrowser-tab, #sidebar-main:not(:hover) #vertical-tabs-newtab-button {
@@ -54,6 +63,19 @@
   fill: red !important;
   background-color: transparent !important;
   padding: 5px !important;
+}
+/* Sidebar extensions */
+#sidebar-box {
+  z-index: 100 !important;
+  position: absolute !important;
+  height: 100% !important;
+  margin-left: var(--left-margin);
+  width: var(--custom-tab-width);
+}
+#sidebar-box #sidebar {
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
 }
 
 
@@ -137,6 +159,10 @@
 
   #TabsToolbar .titlebar-buttonbox-container {
     visibility: hidden !important;
+  }
+  /* fix for sidebar color on linux */
+  #sidebar-main {
+    background: var(--sidebar-background-color)
   }
 }
 

--- a/userChrome.css
+++ b/userChrome.css
@@ -11,8 +11,12 @@
   z-index: 9999;
 }
 /* Hides the sidebar when in fullscreen */
-[inFullscreen] #sidebar-main {
-  display: none !important;
+[inFullscreen] #sidebar-main:not(:hover) {
+  opacity: 0 !important;
+}
+/* Shows the sidebar when in fullscreen and hovering */
+[inFullscreen] #sidebar-main:hover {
+  opacity: 1 !important;
 }
 /* The browser-content */
 #tabbrowser-tabbox {
@@ -27,8 +31,7 @@
 }
 /* Hides the sidebar when in fullscreen video */
 [inFullscreen] #tabbrowser-tabbox[sidebar-shown] {
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin: 0 !important;
 }
 /* When not hovering cancel the default crap behavior of the expanded feature */
 #sidebar-main:not(:hover), #sidebar-main:not(:hover) .tabbrowser-tab, #sidebar-main:not(:hover) #vertical-tabs-newtab-button {

--- a/userChrome.css
+++ b/userChrome.css
@@ -2,12 +2,6 @@
 * {
   scrollbar-width: none !important;
   --custom-tab-width: 226px; /* custom-bar-width  minus  2*custom-bar-padding */
-  --custom-bar-hover-width: 245px;
-  --custom-bar-padding: 9px;
-  --left-side: 0; /* Swap with --right-side value to put the bar on the right side */
-  --right-side: auto;
-  --left-margin: 61.2333px; /* swap with --right-margin to offset the browser content correctly when using a right sidebar */
-  --right-margin: auto;
 }
 
 /* The sidebar containing the tabs */
@@ -25,8 +19,7 @@
 }
 /* The sidebar when enabled */
 #tabbrowser-tabbox[sidebar-shown] {
-  margin-left: var(--left-margin) !important;
-  margin-right: var(--right-margin) !important;
+  margin-left: var(--tab-collapsed-width) !important;
 }
 /* Hides the sidebar when in fullscreen */
 [inFullscreen] #tabbrowser-tabbox[sidebar-shown] {
@@ -35,7 +28,7 @@
 }
 /* When not hovering cancel the default crap behavior of the expanded feature */
 #sidebar-main:not(:hover), #sidebar-main:not(:hover) .tabbrowser-tab, #sidebar-main:not(:hover) #vertical-tabs-newtab-button {
-  width: var(--left-margin) !important;
+  width: var(--tab-collapsed-width) !important;
   min-width: 0 !important;
 }
 /* Use the new crappy expanded shit to add the sidebar background when expanded */
@@ -45,10 +38,6 @@
 /* on hover correct width for tab background */
 #vertical-tabs:hover .tab-background {
   width: var(--custom-tab-width) !important;
-}
-/* Align the tab contents nicely */
-.tab-icon-image, .tab-label-container, .tab-content {
-  padding-left: var(--custom-bar-padding) !important;
 }
 /* display close button and site title on hover of sidebar */
 #sidebar-main:hover .tab-label-container, #sidebar-main:hover .tab-close-button, #sidebar-main:hover .toolbarbutton-text {
@@ -69,7 +58,7 @@
   z-index: 100 !important;
   position: absolute !important;
   height: 100% !important;
-  margin-left: var(--left-margin);
+  margin-left: var(--tab-collapsed-width);
   width: var(--custom-tab-width);
 }
 #sidebar-box #sidebar {

--- a/userChrome.css
+++ b/userChrome.css
@@ -10,6 +10,10 @@
   height: 100%; /* The height is set to ensure the sidebar will also use it */
   z-index: 9999;
 }
+/* Hides the sidebar when in fullscreen */
+[inFullscreen] #sidebar-main {
+  display: none !important;
+}
 /* The browser-content */
 #tabbrowser-tabbox {
   margin-left: 0 !important;
@@ -21,7 +25,7 @@
 #tabbrowser-tabbox[sidebar-shown] {
   margin-left: var(--tab-collapsed-width) !important;
 }
-/* Hides the sidebar when in fullscreen */
+/* Hides the sidebar when in fullscreen video */
 [inFullscreen] #tabbrowser-tabbox[sidebar-shown] {
   margin-left: 0 !important;
   margin-right: 0 !important;

--- a/versions/v135/userChrome.css
+++ b/versions/v135/userChrome.css
@@ -11,8 +11,12 @@
   z-index: 9999;
 }
 /* Hides the sidebar when in fullscreen */
-[inFullscreen] #sidebar-main {
-  display: none !important;
+[inFullscreen] #sidebar-main:not(:hover) {
+  opacity: 0 !important;
+}
+/* Shows the sidebar when in fullscreen and hovering */
+[inFullscreen] #sidebar-main:hover {
+  opacity: 1 !important;
 }
 /* The browser-content */
 #tabbrowser-tabbox {
@@ -27,8 +31,7 @@
 }
 /* Hides the sidebar when in fullscreen video */
 [inFullscreen] #tabbrowser-tabbox[sidebar-shown] {
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin: 0 !important;
 }
 /* When not hovering cancel the default crap behavior of the expanded feature */
 #sidebar-main:not(:hover), #sidebar-main:not(:hover) .tabbrowser-tab, #sidebar-main:not(:hover) #vertical-tabs-newtab-button {

--- a/versions/v135/userChrome.css
+++ b/versions/v135/userChrome.css
@@ -1,4 +1,4 @@
-/* Firefox Version 130.0 Custom CSS for vertical tabs */
+/* Firefox Version 135.0 Custom CSS for vertical tabs */
 * {
   scrollbar-width: none !important;
   --custom-tab-width: 226px; /* custom-bar-width  minus  2*custom-bar-padding */
@@ -18,11 +18,20 @@
 }
 /* The browser-content */
 #tabbrowser-tabbox {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+/* The sidebar when enabled */
+#tabbrowser-tabbox[sidebar-shown] {
   margin-left: var(--left-margin) !important;
   margin-right: var(--right-margin) !important;
 }
-[inFullscreen] #tabbrowser-tabbox {
-  margin-left: var(--left-margin) !important;
+/* Hides the sidebar when in fullscreen */
+[inFullscreen] #tabbrowser-tabbox[sidebar-shown] {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
 }
 /* When not hovering cancel the default crap behavior of the expanded feature */
 #sidebar-main:not(:hover), #sidebar-main:not(:hover) .tabbrowser-tab, #sidebar-main:not(:hover) #vertical-tabs-newtab-button {
@@ -54,6 +63,19 @@
   fill: red !important;
   background-color: transparent !important;
   padding: 5px !important;
+}
+/* Sidebar extensions */
+#sidebar-box {
+  z-index: 100 !important;
+  position: absolute !important;
+  height: 100% !important;
+  margin-left: var(--left-margin);
+  width: var(--custom-tab-width);
+}
+#sidebar-box #sidebar {
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
 }
 
 
@@ -137,6 +159,10 @@
 
   #TabsToolbar .titlebar-buttonbox-container {
     visibility: hidden !important;
+  }
+  /* fix for sidebar color on linux */
+  #sidebar-main {
+    background: var(--sidebar-background-color)
   }
 }
 

--- a/versions/v135/userChrome.css
+++ b/versions/v135/userChrome.css
@@ -2,12 +2,6 @@
 * {
   scrollbar-width: none !important;
   --custom-tab-width: 226px; /* custom-bar-width  minus  2*custom-bar-padding */
-  --custom-bar-hover-width: 245px;
-  --custom-bar-padding: 9px;
-  --left-side: 0; /* Swap with --right-side value to put the bar on the right side */
-  --right-side: auto;
-  --left-margin: 61.2333px; /* swap with --right-margin to offset the browser content correctly when using a right sidebar */
-  --right-margin: auto;
 }
 
 /* The sidebar containing the tabs */
@@ -25,8 +19,7 @@
 }
 /* The sidebar when enabled */
 #tabbrowser-tabbox[sidebar-shown] {
-  margin-left: var(--left-margin) !important;
-  margin-right: var(--right-margin) !important;
+  margin-left: var(--tab-collapsed-width) !important;
 }
 /* Hides the sidebar when in fullscreen */
 [inFullscreen] #tabbrowser-tabbox[sidebar-shown] {
@@ -35,7 +28,7 @@
 }
 /* When not hovering cancel the default crap behavior of the expanded feature */
 #sidebar-main:not(:hover), #sidebar-main:not(:hover) .tabbrowser-tab, #sidebar-main:not(:hover) #vertical-tabs-newtab-button {
-  width: var(--left-margin) !important;
+  width: var(--tab-collapsed-width) !important;
   min-width: 0 !important;
 }
 /* Use the new crappy expanded shit to add the sidebar background when expanded */
@@ -45,10 +38,6 @@
 /* on hover correct width for tab background */
 #vertical-tabs:hover .tab-background {
   width: var(--custom-tab-width) !important;
-}
-/* Align the tab contents nicely */
-.tab-icon-image, .tab-label-container, .tab-content {
-  padding-left: var(--custom-bar-padding) !important;
 }
 /* display close button and site title on hover of sidebar */
 #sidebar-main:hover .tab-label-container, #sidebar-main:hover .tab-close-button, #sidebar-main:hover .toolbarbutton-text {
@@ -69,7 +58,7 @@
   z-index: 100 !important;
   position: absolute !important;
   height: 100% !important;
-  margin-left: var(--left-margin);
+  margin-left: var(--tab-collapsed-width);
   width: var(--custom-tab-width);
 }
 #sidebar-box #sidebar {

--- a/versions/v135/userChrome.css
+++ b/versions/v135/userChrome.css
@@ -10,6 +10,10 @@
   height: 100%; /* The height is set to ensure the sidebar will also use it */
   z-index: 9999;
 }
+/* Hides the sidebar when in fullscreen */
+[inFullscreen] #sidebar-main {
+  display: none !important;
+}
 /* The browser-content */
 #tabbrowser-tabbox {
   margin-left: 0 !important;
@@ -21,7 +25,7 @@
 #tabbrowser-tabbox[sidebar-shown] {
   margin-left: var(--tab-collapsed-width) !important;
 }
-/* Hides the sidebar when in fullscreen */
+/* Hides the sidebar when in fullscreen video */
 [inFullscreen] #tabbrowser-tabbox[sidebar-shown] {
   margin-left: 0 !important;
   margin-right: 0 !important;


### PR DESCRIPTION
* Fixes the sidebar being visible in fullscreen/fullscreen youtube
* Fixes the Sidebar-box so it does not overlap with the sidebar
* Swapped to [sidebar-shown] instead of having a grey empty box
* removed ugly outline
* removed ugly shadow

It seems like the devs messed up the sidebar stuff this time around, also there is a backend difference between Windows and Linux release...
* the biggest annoyance being the 100% height in `sidebar-main` goes off screen at the bottom... `bottom: 0` makes it overlap with the bookmarksbar etc..
* the second annoyance was the sidebar background being transparent with auto theme, with dark mode there is 2 different colors, however i get the real color when hovering atleast
* another issue being the width not being respected in `sidebar-box`, i've also noticed this in other places, but not a big issue

1 question i have tho, why `--left-margin: 61.2333px;`?